### PR TITLE
Fixes to appendices, Indicator light and casing

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,9 +140,9 @@
 
           <p>Alcune informazioni per il disarmo, richiederanno informazioni
             specifiche riguardo la bomba, come il numero seriale. Questo tipo di
-            informazioni, possono essere trovate sopra, sotto o ai lati della
-            bomba. Controlla l'Appendice A, B e C per identificare le istruzioni
-            che saranno utilissime per disarmare certi moduli.</p>
+            informazioni, possono solitamente essere trovate sopra, sotto o ai lati del
+            rivestimento della bomba. Controlla l'Appendice A, B e C per identificare
+            le istruzioni che saranno utilissime per disarmare certi moduli.</p>
         </div>
         <div class="page-footer relative-footer"></div>
       </div>
@@ -249,8 +249,8 @@
             ragionamenti che fanno saltare in aria le persone.</p>
 
           <p class="appendix-reference">
-            Vedi Appendice A per poter identificare gli indicatori.<br/>
-            Vedi Appendice B per poter identificare le batterie.</p>
+            Vedi Appendice A per la guida all'identificazione delle spie.<br/>
+            Vedi Appendice B per la guida all'identificazione delle batterie.</p>
 
           <p>Segui queste regole nell'ordine con cui sono scritte. Esegui la prima
             azione compatibile:</p>
@@ -262,13 +262,12 @@
             <li>Se ci sono più di una batteria sulla bomba e sul bottone c'è scritto
               "Detonate", premi e rilascia immediatamente il bottone.
             </li>
-            <li>Se il bottone è bianco e c'è un indicatore acceso sulla bomba
-              con scritto CAR, premi e tieni premuto il bottone e fai riferimento alla sezione
+            <li>Se il bottone è bianco e c'è una spia accesa etichettata CAR,
+              premi e tieni premuto il bottone e fai riferimento alla sezione
               "Rilasciare un bottone premuto".
             </li>
-            <li>Se ci sono più di due batterie sulla bomba e c'è un indicatore
-              acceso sulla bomba con scritto FRK, premi e rilascia immediatamente
-              il bottone.
+            <li>Se ci sono più di 2 batterie sulla bomba e c'è una spia accesa
+              etichettata FRK, premi e rilascia immediatamente il bottone.
             </li>
             <li>Se il bottone è giallo, premi e tieni premuto il bottone e fai
               riferimento alla sezione "Rilasciare un bottone premuto".
@@ -1705,8 +1704,9 @@
             </table>
           </div>
           <div style="clear:both;"/>
-          <p class="appendix-reference">Vedi Appendice B per l'identificazione delle batterie.<br/>
-            Vedi Appendice C per l'identificazione delle porte.</p></div>
+          <p class="appendix-reference">
+            Vedi Appendice B per la guida all'identificazione delle batterie.<br/>
+            Vedi Appendice C per la guida all'identificazione delle porte.</p></div>
         <div class="page-footer relative-footer"></div>
       </div>
     </div>
@@ -2263,13 +2263,13 @@
         </div>
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
-          <h2>Appendice A: Identificazione degli indicatori</h2>
+          <h2>Appendice A: Guida all'identificazione delle spie</h2>
 
-          <p>Gli indicatori accesi si trovano ai lati della bomba.</p>
+          <p>Spie etichettate possono essere trovate sul rivestimento della bomba.</p>
           <img src="img/IndicatorWidget.svg"
                style="height: 5em; display:block; margin: .6em 0 0;"/>
 
-          <h3>Indicatori comuni</h3>
+          <h3>Spie comuni</h3>
           <ul>
             <li>SND</li>
             <li>CLR</li>
@@ -2295,9 +2295,10 @@
         </div>
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
-          <h2>Appendice B: Identificazione delle batterie</h2>
+          <h2>Appendice B: Guida all'identificazione delle batterie</h2>
 
-          <p>Le batterie sono di tipo comune e si trovano ai lati della bomba.</p>
+          <p>Batterie di tipo comune possono essere torvate all'interno di alloggiamenti
+            sul rivestimento della bomba.</p>
           <table style="margin-top: 1em;">
             <tr>
               <th>Batteria</th>
@@ -2326,9 +2327,9 @@
         </div>
         <div class="page-footer absolute-footer"></div>
         <div class="page-content">
-          <h2>Appendice C: Identificazione Porte</h2>
+          <h2>Appendice C: Guida all'identificazione delle porte</h2>
 
-          <p>Le porte digitali ed analogiche si trovano ai lati della bomba.</p>
+          <p>Porte digitali ed analogiche possono essere trovate sul rivestimento della bomba.</p>
           <table>
             <tr>
               <th>Porta</th>

--- a/index.html
+++ b/index.html
@@ -2265,7 +2265,7 @@
         <div class="page-content">
           <h2>Appendice A: Guida all'identificazione delle spie</h2>
 
-          <p>Spie etichettate possono essere trovate sul rivestimento della bomba.</p>
+          <p>Spie e relative etichette possono essere trovate sul rivestimento della bomba.</p>
           <img src="img/IndicatorWidget.svg"
                style="height: 5em; display:block; margin: .6em 0 0;"/>
 

--- a/index.html
+++ b/index.html
@@ -2297,7 +2297,7 @@
         <div class="page-content">
           <h2>Appendice B: Guida all'identificazione delle batterie</h2>
 
-          <p>Batterie di tipo comune possono essere torvate all'interno di alloggiamenti
+          <p>Batterie di tipo comune possono essere trovate all'interno di alloggiamenti
             sul rivestimento della bomba.</p>
           <table style="margin-top: 1em;">
             <tr>


### PR DESCRIPTION
Changed indicator light to "spie"
Changed reference to "guide"
Changed casing to "rivestimento"
Added a few missing words (tipically, enclosures)

The English manual says in the appendices "on the side of the bomb casing" but
I have taken the liberty to translate this to "sul rivestimento della bomba" as
it seems to convey what I see in the game better than the litteral translation.